### PR TITLE
#74: Fix DatePickers initial value in Logs

### DIFF
--- a/webapp/app/components/Logs/Filters/DateRange.js
+++ b/webapp/app/components/Logs/Filters/DateRange.js
@@ -3,6 +3,7 @@
 //
 
 import React from 'react';
+import moment from 'moment';
 import DatePicker from 'components/DatePicker';
 import RadioGroup from 'components/RadioGroup';
 import styles from './styles.css';
@@ -19,8 +20,8 @@ export default class DateRange extends React.Component {
     super(props);
     this.state = {
       specific: true,
-      dateOne: null,
-      dateTwo: null,
+      dateOne: moment().startOf('day').toString(),
+      dateTwo: moment().startOf('day').toString(),
     };
   }
 


### PR DESCRIPTION
Ended up putting current day instead of null to avoid fetching all logs when filters stay untouched
