### PR TITLE
#319 remove warnings on statistic module

### DIFF
--- a/webapp/app/components/Stats/StatisticGraph/index.js
+++ b/webapp/app/components/Stats/StatisticGraph/index.js
@@ -69,7 +69,5 @@ export class StatisticGraphComponent extends React.Component {
 
 StatisticGraphComponent.propTypes = {
   getGraphListByType: React.PropTypes.func.isRequired,
-  getGraphFromServer: React.PropTypes.func.isRequired,
-  clearGraph: React.PropTypes.func.isRequired,
   stats: React.PropTypes.object.isRequired,
 };

--- a/webapp/app/components/Stats/index.js
+++ b/webapp/app/components/Stats/index.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { PageHeader } from 'react-bootstrap';
-import StatisticFilterComponent from 'containers/Stats/StatisticFilter'
-import StatisticGraphComponent from 'containers/Stats/StatisticGraph'
+import StatisticFilterComponent from 'containers/Stats/StatisticFilter';
+import StatisticGraphComponent from 'containers/Stats/StatisticGraph';
 
 export class StatsComponent extends React.Component {
 
   render() {
-
     return (
       <div>
         <PageHeader>Stats</PageHeader>


### PR DESCRIPTION
#319

Correct warnings on statistic page, only one warning remain, the unknown prop redraw one.
At the bottom of the page of : https://github.com/reactjs/react-chartjs
You will see that the prop actually exist, I think the component have some problem.
Also corrected ESlint validation.
