### PR TITLE
#519: Install gridfs-stream module in order to disable mongoose query array length limit of 1000

### DIFF
--- a/libs/mongoose.js
+++ b/libs/mongoose.js
@@ -1,6 +1,7 @@
 const conf = require('../config/mongoose.config.json');
 
 const mongoose = require('mongoose');
+const Grid = require('gridfs-stream');
 
 mongoose.Promise = global.Promise;
 
@@ -10,5 +11,8 @@ url += `:${conf.port}`;
 url += `/${conf.dbConfig.database}`;
 
 mongoose.connect(url);
+
+// Remove batchSize from mongoose queries
+Grid(mongoose.mongo, mongoose.connection.db);
 
 module.exports = mongoose;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "git-http-backend": "^1.0.2",
     "git-wrapper": "github:eip-sam/node-git-wrapper",
     "glob": "^7.1.1",
+    "gridfs-stream": "^1.1.1",
     "helmet": "^2.3.0",
     "moment": "^2.17.1",
     "mongoose": "^4.6.5",


### PR DESCRIPTION
#519 